### PR TITLE
Chinese region and read fonts from korean and chinese TWLFontTable.dat

### DIFF
--- a/TWLFontTableDumper/Program.cs
+++ b/TWLFontTableDumper/Program.cs
@@ -39,6 +39,11 @@ namespace TWLFontTableDumper
             {
                 Console.WriteLine($"Found resource {resource.ResourceName} (Size: {resource.CompressedResourceSize}," +
                     $" SHA1: {BitConverter.ToString(resource.CompressedResourceSHA1).Replace("-", "")})");
+                if (resource.CompressedResourceSize == 0)
+                {
+                    Console.WriteLine($"Empty resource, omitting");
+                    continue;
+                }
                 try
                 {
                     var writer = resource.GetWriter();

--- a/TWLFontTableDumper/TWLFontTable.cs
+++ b/TWLFontTableDumper/TWLFontTable.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2018 RonnChyran
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace TWLFontTableDumper
 {
@@ -30,7 +29,8 @@ namespace TWLFontTableDumper
         private Stream TWLFontTableDat { get; }
 
         private static readonly int NFTRResourceCountOffset = 0x0084;
-        
+        private static readonly int NFTRRegionOffset = 0x0086;
+
         // We should check this, but since there is not much information available on
         // CHN and KOR regions, can not be sure that the RSA Signature matches up with
         // font files on such systems.
@@ -68,19 +68,22 @@ namespace TWLFontTableDumper
 
         /// <summary>
         /// Determines the region of the TWLFontTableRegion
-        /// by number of resources.
-        /// 3 - Normal (USA/JAP/EUR/AUS)
-        /// 9 - KOR
-        /// 5 - CHN (?)
+        /// by the byte at 0x0086.
+        /// 0 - Normal (USA/JAP/EUR/AUS)
+        /// 4 - CHN
+        /// 5 - KOR
         /// </summary>
         /// <returns></returns>
         private TWLFontTableRegions GetTWLFontTableRegions()
         {
-            switch (this.NFTRResourceCount)
+            this.TWLFontTableDat.Seek(NFTRRegionOffset, SeekOrigin.Begin);
+            switch (this.TWLFontTableDat.ReadByte())
             {
-                case 3:
+                case 0:
                     return TWLFontTableRegions.Normal;
-                case 9:
+                case 4:
+                    return TWLFontTableRegions.China;
+                case 5:
                     return TWLFontTableRegions.Korea;
                 default:
                     return TWLFontTableRegions.Unknown;

--- a/TWLFontTableDumper/TWLFontTableRegions.cs
+++ b/TWLFontTableDumper/TWLFontTableRegions.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace TWLFontTableDumper
 {
     public enum TWLFontTableRegions
     {
         Unknown,
         Normal,
+        China,
         Korea,
     }
 }


### PR DESCRIPTION
Fix to Issue #2 
I added a chinese region and now the region gets checked not on resources amount (it is the same for Chinese and Korean TWLFontTable.dat) but rather on byte 0x0086h. From gbatek documentation:
```
  0000h       80h  RSA-SHA1 on entries [0080h..009Fh] (23h,8Bh,F9h,08h,...)
  0080h       4    Date? (00h,31h,07h,08h=Normal, 00h,27h,05h,09h=China/Korea)
  0084h       1    Number of NFTR resources (NUM) (3=Normal, 9=China/Korea)
  0085h       1    Zerofilled
  0086h       1    Unknown (0=Normal, 4=China, 5=Korea)   <--------------------------
  0087h       5    Zerofilled
  008Ch       14h  SHA1 on below resource headers at [00A0h+(0..NUM*40h-1)]
  00A0h+N*40h 20h  Resource Name in ASCII, padded with 00h
  00C0h+N*40h 4    Compressed Resource Size in .dat file   ;\compressed
  00C4h+N*40h 4    Compressed Resource Start in .dat file  ;/
  00C8h+N*40h 4    Decompressed Resource Size              ;-decompressed
  00CCh+N*40h 14h  SHA1 on Compressed Resource at [Start+0..Size-1]
  ...         ..   Compressed Font Resources (with 16-byte alignment padding)
```

And when the resource size is 0, it gets skipped so as not to crash the script.